### PR TITLE
Moment version upgrade (Mianly for timezone support)

### DIFF
--- a/package.js
+++ b/package.js
@@ -9,15 +9,15 @@ Package.describe({
 Package.onUse(function(api) {
   api.versionsFrom("METEOR@0.9.0");
 
-  api.use(['momentjs:moment@2.9.0'], ['client', 'server']);
+  api.use(['momentjs:moment@2.10.6'], ['client', 'server']);
 
-  api.addFiles('lib/moment-range/lib/moment-range.bare.js');
+  api.addFiles('lib/moment-range/dist/moment-range.js');
 });
 
 Package.on_test(function (api) {
   api.use([
     'jquery@1.0.0',
-    'momentjs:moment@2.9.0'
+    'momentjs:moment@2.10.6'
   ]);
-  api.addFiles('lib/moment-range/lib/moment-range.bare.js');
+  api.addFiles('lib/moment-range/dist/moment-range.js');
 });


### PR DESCRIPTION
Pretty simple version upgrade which brings Moment 2.10.x Timezone support along with it.  Should be entirely reverse-compatible.  Addresses the Issue I opened up a little while ago (#1).  I've been using this since I opened that with no problems.

Please consider this PR!  Otherwise it's only a matter of time until someone makes a new Atmosphere package unnecessarily. :smiley_cat: 
